### PR TITLE
Fix: encoding not forwarded to featureCollection call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 build/
 pubspec.lock
 doc/api/
+.idea/
+.fvm/

--- a/lib/src/data/index.dart
+++ b/lib/src/data/index.dart
@@ -25,8 +25,10 @@ Map<String, Function> _types = {
 /// shapefile.
 ///
 /// The [source] must be a chunked byte-stream.
-Stream<Map<String, dynamic>> data(Stream<List<int>> source,
-    {Encoding encoding = utf8}) async* {
+Stream<Map<String, dynamic>> data(
+  Stream<List<int>> source, {
+  Encoding encoding = utf8,
+}) async* {
   var r = ChunkedStreamReader(source),
       head = ByteData.sublistView(await r.readBytes(32)),
       body = ByteData.sublistView(

--- a/lib/src/features/index.dart
+++ b/lib/src/features/index.dart
@@ -11,11 +11,13 @@ import '../geometries/index.dart';
 ///
 /// The follwing option are supported: `encoding` - the dBASE character
 /// encoding; defaults to “UTF-8”
-Stream<Map<String, dynamic>> features(Stream<List<int>> shp,
-    {Stream<List<int>>? dbf,
-    Encoding encoding = utf8,
-    void Function(List<double>)? forBbox}) {
-  var streams = [geometries(shp, forBbox: forBbox)];
+Stream<Map<String, dynamic>> features(
+  Stream<List<int>> shp, {
+  Stream<List<int>>? dbf,
+  Encoding encoding = utf8,
+  void Function(List<double>)? forBbox,
+}) {
+  final streams = [geometries(shp, forBbox: forBbox)];
   if (dbf != null) streams.add(data(dbf, encoding: encoding));
   return StreamZip(streams).map((results) => {
         "type": "Feature",
@@ -43,12 +45,18 @@ Stream<Map<String, dynamic>> features(Stream<List<int>> shp,
 /// [Proj4js](https://github.com/proj4js/proj4js) for parsing
 /// [well-known text (WKT)](https://en.wikipedia.org/wiki/Well-known_text#Coordinate_reference_system)
 /// specifications.
-Future<Map<String, dynamic>> featureCollection(Stream<List<int>> shp,
-    {Stream<List<int>>? dbf, Encoding encoding = utf8}) async {
-  var collection = <String, dynamic>{
+Future<Map<String, dynamic>> featureCollection(
+  Stream<List<int>> shp, {
+  Stream<List<int>>? dbf,
+  Encoding encoding = utf8,
+}) async {
+  final collection = <String, dynamic>{
     "type": "FeatureCollection",
   };
-  collection["features"] = await features(shp,
-      dbf: dbf, forBbox: (bbox) => collection["bbox"] = bbox).toList();
+  collection["features"] = await features(
+    shp,
+    dbf: dbf,
+    forBbox: (bbox) => collection["bbox"] = bbox,
+  ).toList();
   return collection;
 }

--- a/lib/src/features/index.dart
+++ b/lib/src/features/index.dart
@@ -57,6 +57,7 @@ Future<Map<String, dynamic>> featureCollection(
     shp,
     dbf: dbf,
     forBbox: (bbox) => collection["bbox"] = bbox,
+    encoding: encoding,
   ).toList();
   return collection;
 }


### PR DESCRIPTION
I was wondering how to configure the encoder to make use of the "allowMalformed" property and then figured out that the parameter that configures it has not been forwarded to the featureCollection call.
I've added this so that now the encoding is configurable.
The most relevant change is in lib/src/features/index.dart.
The rest is just minor coding improvements I did to help me with readability.